### PR TITLE
Switch to Podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ up:
 local:
 	pdm run python -m ilo
 
+stop:
+	docker compose stop
+
 down:
 	docker compose down
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+MAIN=podman
+SUB=podman-compose
+# MAIN=docker
+# SUB=docker compose
+
 init:
 	pdm install
 	# pdm run pre-commit install
@@ -6,27 +11,27 @@ test:
 	pdm run pytest -rP ./tests
 
 build:
-	docker compose build
+	${SUB} build
 
 up:
-	docker compose up -d
+	${SUB} up -d
 
 local:
 	pdm run python -m ilo
 
 stop:
-	docker compose stop
+	${SUB} stop
 
 down:
-	docker compose down
+	${SUB} down
 
 logs:
-	docker compose logs
+	${SUB} logs
 
 import:
 	# container must be running
-	docker cp ./userdata/preferences.json $(shell docker ps | grep ilo-linku | awk '{print $$1}'):/project/userdata/preferences.json
+	${MAIN} cp ./userdata/preferences.json $(shell ${MAIN} ps | grep ilo-linku | awk '{print $$1}'):/project/userdata/preferences.json
 
 export:
 	# container must be running
-	docker cp $(shell docker ps | grep ilo-linku | awk '{print $$1}'):/project/userdata/preferences.json ./userdata/preferences.json
+	${MAIN} cp $(shell ${MAIN} ps | grep ilo-linku | awk '{print $$1}'):/project/userdata/preferences.json ./userdata/preferences.json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@
 
 ### Prerequisites
 
-To run in Docker environment:
+To run in a Podman environment (default):
+
+- Python 3.8+
+- [pdm](https://github.com/pdm-project/pdm)
+- [Podman](https://podman.io/)
+- [Podman Compose](https://github.com/containers/podman-compose)
+
+To run in Docker environment (see `Makefile`):
 
 - Python 3.8+
 - [pdm](https://github.com/pdm-project/pdm)
@@ -25,6 +32,7 @@ To run locally:
 - [pdm](https://github.com/pdm-project/pdm)
 - [fribidi](https://github.com/fribidi/fribidi)
 - [libraqm](https://github.com/HOST-Oman/libraqm)
+- Install your dependencies with pdm: `pdm install` or `make init`
 
 You likely already have the last two, but a symptom of not having them is that `/sp` will emit normal text instead of sitelen pona!
 
@@ -41,7 +49,6 @@ You likely already have the last two, but a symptom of not having them is that `
     - Embed Links
     - Attach Files
     - Use Slash Commands
-- Install Python dependencies: `pdm install`
 - Save your bot token to a `.env` file as `DISCORD_TOKEN=longstringofcharactersyougotfromtheportal`.
 - Run the bot: `make build up` or `make local`, if you want the containerized or local bot respectively.
 

--- a/src/ilo/preferences.py
+++ b/src/ilo/preferences.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from ilo.colour import is_colour
 from ilo.defines import acro_choices, text
@@ -18,7 +19,11 @@ class PreferenceHandler:
             Template("language", "en", get_languages_for_slash_commands()),
         ]
         self.templates = {template.name: template for template in self.templates}
-        self.userdata = self.from_json()
+        if os.path.exists(PREFERENCES_PATH):
+            self.userdata = self.from_json()
+        else:
+            self.userdata = {}
+            self.to_json()
 
     def from_json(self):
         with open(PREFERENCES_PATH, encoding="utf-8") as f:


### PR DESCRIPTION
Minor functional change to go with this: if the preferences file does not exist, we create it.

This allows the container to persist at runtime so you can import/export the database without the container dying.
podman isn't responsible for the container after it starts, so this and a systemd service are necessary. Fortunately, `podman generate systemd --new --name ilo-linku`