### PR TITLE
[/nimi] Present "book":"none" as "no book"

### DIFF
--- a/src/ilo/cogs/nimi/cog.py
+++ b/src/ilo/cogs/nimi/cog.py
@@ -58,7 +58,7 @@ def embed_response(word, lang, response, embedtype):
         else "(en) {}".format(response["def"]["en"])
     )
     usage = response["usage_category"] if "usage_category" in response else "unknown"
-    embed.add_field(name="usage", value=f"{usage} ({response['book']})")
+    embed.add_field(name="usage", value=f"{usage} ({response['book'].replace("none", "no book"})")
 
     if embedtype == "concise":
         embed.add_field(name="description", value=description)


### PR DESCRIPTION
On discord, when there is no book, the usage presentation can be confusing to look at - for example, `obscure (none)`

There isn't an indication of what "none" means to someone who isn't familiar with the bot. People new to the language are the users who need the most support, so we can make this clearer by saying "no book" instead of "none", visually