### PR TITLE
Implement contrast checker

### DIFF
--- a/src/ilo/sitelen.py
+++ b/src/ilo/sitelen.py
@@ -6,33 +6,61 @@ from PIL import Image, ImageDraw, ImageFont
 BLACK = (0x36, 0x39, 0x3F, 0xFF)
 WHITE = (0xF0, 0xF0, 0xF0, 0xFF)
 TRANSPARENT = (0, 0, 0, 0)
-MINIMUM_BRIGHTNESS = 0x40
 
+def subpixel_luminance(num: int) -> float:
+    srgb = num / 255
+    if srgb <= 0.04045:
+        return srgb / 12.92
+    else:
+        return ((srgb + 0.055) / 1.055) ** 2.4 
 
-def luminance(color: Tuple[int, int, int]) -> float:
-    # NOTE: normally luminance is 0.0-1.0, we are going 0.0-255.0
-    r, g, b = color
+def relative_luminance(color: Tuple[int, int, int]) -> float:
+    r = subpixel_luminance(color[0])
+    g = subpixel_luminance(color[1])
+    b = subpixel_luminance(color[2])
     return 0.2126 * r + 0.7152 * g + 0.0722 * b
 
+def contrast_ratio(color1: Tuple[int, int, int], color2: Tuple[int, int, int]) -> float:
+    luminance1 = relative_luminance(color1)
+    luminance2 = relative_luminance(color2)
+    minimum = min(luminance1, luminance2)
+    maximum = max(luminance1, luminance2)
+    return (maximum + 0.05) / (minimum + 0.05)
+
+def passes_aa(color: Tuple[int, int, int], bg_color: Tuple[int, int, int], font_size: int) -> bool:
+    minimum_ratio = None
+    if font_size < 20:
+        minimum_ratio = 4.5
+    else:
+        minimum_ratio = 3
+
+    return minimum_ratio <= contrast_ratio(color, bg_color)
+
+def midpoint(a: int, b: int) -> int:
+    return round((a + b) / 2)
+
+def midpoint_color(color1: Tuple[int, int, int], color2: Tuple[int, int, int]) -> Tuple[int, int, int]:
+    return (
+        midpoint(color1[0], color2[0]),
+        midpoint(color1[1], color2[1]),
+        midpoint(color1[2], color2[2]),
+    )
 
 def get_bg_stroke_colors(
-    color: Tuple[int, int, int],
-    bgstyle: Literal["outline"] | Literal["background"],
+     color: Tuple[int, int, int],
+     bgstyle: Literal["outline"] | Literal["background"],
+     font_size: int,
 ):
-    bg_color = BLACK
-    stroke_color = BLACK
-
-    # if (sum(color) / len(color)) < MINIMUM_BRIGHTNESS:
-    # if luminance(color) < MINIMUM_BRIGHTNESS:
-    if all(map(lambda c: c < MINIMUM_BRIGHTNESS, color)):
-        bg_color = WHITE
-        stroke_color = WHITE
-
     if bgstyle == "outline":
-        bg_color = TRANSPARENT
+        passes_on_dark = passes_aa(color, BLACK, font_size)
+        passes_on_light = passes_aa(midpoint_color(color, BLACK), WHITE, font_size)
+        if passes_on_dark and passes_on_light:
+            return TRANSPARENT, BLACK
 
-    return bg_color, stroke_color
-
+    if passes_aa(color, BLACK, font_size):
+        return BLACK, TRANSPARENT
+    else:
+        return WHITE, TRANSPARENT
 
 # by jan Tepo
 def display(
@@ -45,7 +73,7 @@ def display(
     STROKE_WIDTH = round((font_size / 133) * 5)
     LINE_SPACING = round((font_size / 11) * 2)
 
-    bg_color, stroke_color = get_bg_stroke_colors(color, bgstyle)
+    bg_color, stroke_color = get_bg_stroke_colors(color, bgstyle, font_size)
     font = ImageFont.truetype(font_path, font_size)
     d = ImageDraw.Draw(Image.new("RGBA", (0, 0), (0, 0, 0, 0)))
     x, y, w, h = d.multiline_textbbox(


### PR DESCRIPTION
What I've implemented is best described with this pseudocode

```
if user uses outline {
    check if the following are both readable:
        - user's text color on dark background
        - mid point of user's color and the outline color on light background

    if readable {
        use it
    } else {
        // since it has been noted white outline is very unreadable
        force use background
    }
}
if user uses background {
    if dark background is readable {
        use dark background
    } else {
        use light background
    }
}
```

# Additional Notes:

- I've used the WCAG's recommendation using the AA contrast ratio [(More Info)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast), everything is on spec with exception to checking whether the outline is readable on light background, I've treated the whole text as if it has solid color and the color is the midpoint of inner color and the outline
- It has been noted that white outline is very unreadable, so we instead use background
- The font size is also considered but it did very little help since pretty much every text here have heading size. but I've implemented it anyway
- **Please test it**, it's untested, please tell me if you're satisfied with this.
- I'm very unfamiliar with programming with python, you can change it to something more idiomatic