### PR TITLE
fixes descriptions after defaulting back to showing words

### DIFF
--- a/src/ilo/cogs/nimi/locale.json
+++ b/src/ilo/cogs/nimi/locale.json
@@ -3,19 +3,19 @@
   "nimi-query": "The word you want to get the translation of.",
   "nimi-sandbox": "Whether to search the sandbox, a collection of unused words.",
   "nimi-language": "The language you want to see definitions in (overrides your settings)",
-  "nimi-hide": "Whether to show the word to only you. Defaults to true",
+  "nimi-hide": "Whether to show the word to only you. Defaults to false.",
 
   "n": "Get the definition of a toki pona word",
   "n-query": "The word you want to get the translation of.",
   "n-sandbox": "Whether to search the sandbox, a collection of unused words.",
   "n-language": "The language you want to see definitions in (overrides your settings)",
-  "n-hide": "Whether to show the word to only you. Defaults to true",
+  "n-hide": "Whether to show the word to only you. Defaults to false.",
 
   "guess": "Get a random word or definition of a word to figure out.",
   "guess-which": "Hide which, the definition or the word?",
   "guess-usage": "The minimum recognition of the returned word.",
   "guess-language": "The language you want to see definitions in (overrides your settings)",
-  "guess-hide": "Whether to show the guessing game to only you. Defaults to true.",
+  "guess-hide": "Whether to show the guessing game to only you. Defaults to false.",
 
   "prefs-language": "Set the language that dictionary definitions will use",
   "prefs-language-option": "The language you want to use.",


### PR DESCRIPTION
i noticed that these were off (force-pushed because there was a random kemeka submodule commit in here)