### PR TITLE
sitelen sitelen font change

### DIFF
--- a/src/ilo/data.py
+++ b/src/ilo/data.py
@@ -95,7 +95,7 @@ LANGUAGES_FOR_PREFS = {
 }
 USAGES_FOR_PREFS = {usage.name: usage.name for usage in UsageCategory}
 
-SITELEN_SITELEN_FONT = "sitelen Latin (ss)"
+SITELEN_SITELEN_FONT = "sitelen sitelen open"
 DEFAULT_FONT = "nasin sitelen pu mono"
 DEFAULT_FONTSIZE = 72
 DEFAULT_COLOR = "dcdcdc"


### PR DESCRIPTION
We were using the then most complete ligature sitelen sitelen font, but it had drawbacks, such as built-in Latin words under each character and a couple of words missing, and it didn't get maintained. sitelen sitelen open is much more up to date (on a technical level and otherwise) and as a basis it's basically the equivalent of nasin sitelen pu because it uses jan Josan's drawings as a base